### PR TITLE
feature: KarmaGPT

### DIFF
--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -4,11 +4,10 @@ import requests
 
 
 @hook.command("gpt", autohelp=False)
-def chat_gpt(api_key, nick, chan, message):
+def chat_gpt(nick, chan, text):
     prompt = (
-        f"Answer the following question from user {nick} on IRC channel {chan}.\n"
-        f"Your answer must not be longer than 500 character.\n"
-        f"{message}\n"
+        f"Answer the following message from user {nick} on IRC channel {chan}.\n"
+        f"{text}\n"
     )
     api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/completions",
@@ -18,7 +17,7 @@ def chat_gpt(api_key, nick, chan, message):
                            json={
                                "model": "text-davinci-003",
                                "prompt": prompt,
-                               "max_tokens": 2048,
+                               "max_tokens": 100,
                                "temperature": 1,
                                "n": 1,
                                "stream": False,
@@ -26,8 +25,6 @@ def chat_gpt(api_key, nick, chan, message):
                            }
     )
     if resp.status_code == 200:
-        msg = resp.json()["choices"][0]["text"].replace("\n","")
-        print(msg)
+        return resp.json()["choices"][0]["text"].replace("\n","")
     else:
-        print(f"ChatGPT failed with error code {resp.status_code} and message {resp.json()}") 
-    
+         return f"ChatGPT failed with error code {resp.status_code} and message {resp.json()}"

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -1,0 +1,33 @@
+from cloudbot import hook
+from cloudbot.bot import bot
+import requests
+
+
+@hook.command("gpt", autohelp=False)
+def chat_gpt(api_key, nick, chan, message):
+    prompt = (
+        f"Answer the following question from user {nick} on IRC channel {chan}.\n"
+        f"Your answer must not be longer than 500 character.\n"
+        f"{message}\n"
+    )
+    api_key = bot.config.get_api_key("openai")
+    resp = requests.post("https://api.openai.com/v1/completions",
+                           headers={
+                             "Authorization": f"Bearer {api_key}",
+                           },
+                           json={
+                               "model": "text-davinci-003",
+                               "prompt": prompt,
+                               "max_tokens": 2048,
+                               "temperature": 1,
+                               "n": 1,
+                               "stream": False,
+                               "user": f"{hash(nick)}",
+                           }
+    )
+    if resp.status_code == 200:
+        msg = resp.json()["choices"][0]["text"].replace("\n","")
+        print(msg)
+    else:
+        print(f"ChatGPT failed with error code {resp.status_code} and message {resp.json()}") 
+    

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -8,7 +8,6 @@ import textwrap
 RATELIMIT = {}
 
 def check_rate_limit(nick):
-    print(RATELIMIT)
     if RATELIMIT.get(nick, False) == False:
         return True
     time_difference = abs(datetime.now() - RATELIMIT.get(nick))
@@ -49,7 +48,6 @@ def chat_gpt(nick, chan, text):
         answer = resp.json()["choices"][0]["text"].replace("\n","")
         messages = textwrap.wrap(answer,250)
         if len(messages) > 2:
-            # Send the prompt to hastebin
             hastebin_api_key = bot.config.get_api_key("hastebin")
             hastebin_resp = requests.post("https://hastebin.com/documents",
                                           headers={
@@ -59,7 +57,6 @@ def chat_gpt(nick, chan, text):
                                           data="\n".join(messages)
             )
             if hastebin_resp.status_code == 200:
-                # Return first 2 blocks, then direct to hastebin
                 truncated_resp = messages[0:2]
                 truncated_resp.append(f"Find the rest of the answer here: https://hastebin.com/share/{hastebin_resp.json()['key']}") 
                 return truncated_resp

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -1,23 +1,23 @@
 from cloudbot import hook
 from cloudbot.bot import bot
 import requests
+import textwrap
 
 
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text):
     prompt = (
-        f"Answer the following message from user {nick} on IRC channel {chan}.\n"
-        f"{text}\n"
+        f"{nick} on IRC channel {chan} says: {text}\n"
     )
-    api_key = bot.config.get_api_key("openai")
+    open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/completions",
                            headers={
-                             "Authorization": f"Bearer {api_key}",
+                             "Authorization": f"Bearer {open_ai_api_key}",
                            },
                            json={
                                "model": "text-davinci-003",
                                "prompt": prompt,
-                               "max_tokens": 100,
+                               "max_tokens": 1024,
                                "temperature": 1,
                                "n": 1,
                                "stream": False,
@@ -25,6 +25,28 @@ def chat_gpt(nick, chan, text):
                            }
     )
     if resp.status_code == 200:
-        return resp.json()["choices"][0]["text"].replace("\n","")
+        answer = resp.json()["choices"][0]["text"].replace("\n","")
+        messages = textwrap.wrap(answer,250)
+        if len(messages) > 2:
+            # Send the prompt to hastebin
+            hastebin_api_key = bot.config.get_api_key("hastebin")
+            hastebin_resp = requests.post("https://hastebin.com/documents",
+                                          headers={
+                                              "Authorization": f"Bearer {hastebin_api_key}",
+                                              "Content-Type": "text/plain"
+                                          },
+                                          data="\n".join(messages)
+            )
+            if hastebin_resp.status_code == 200:
+                # Return first 2 blocks, then direct to hastebin
+                truncated_resp = messages[0:2]
+                truncated_resp.append(f"Find the rest of the answer here: https://hastebin.com/share/{hastebin_resp.json()['key']}") 
+                return truncated_resp
+            else:
+                return "Hastebin failed with error {hastebin_resp.status_code} and message: {hastebin_resp.json()}"
+        return messages
     else:
-         return f"ChatGPT failed with error code {resp.status_code} and message {resp.json()}"
+         return textwrap.wrap(
+             f"ChatGPT failed with error code {resp.status_code} and message: {resp.json()['error']['message']}",
+             250
+         )


### PR DESCRIPTION
This pull request introduces the `chatgpt.py` plugin to CloudBot.   

Usage: 
```
<foo>: .gpt tell me a joke !
<CloudBot>: Why did the chicken cross the road ? To get to the other side !
```  

Feature list:
 - Command `.gpt` that forwards the message as prompt to ChatGPT API
 -  Bot responds in the IRC channel with wrapped messages of 250 chars. If the answered prompt is longer than 2 messages, the remaining message is uploaded to Hastebin and the link is shared in the channel.  
 -  An in-memory rate limit of 1 invokation/5min/nick to invoke the command
      
Requirements: 
 - An OpenAI API Key that can be obtained [here](https://platform.openai.com/) 
 - A Hastebin API Key that can be obtained [here](https://www.toptal.com/developers/hastebin/documentation)  

Both key must be set in the bots `config.json` `apiKeys` section such as:  
  
```
{
  "api_keys": {
     "openai": "...",
     "hastebin": "...."   
  },
  ...
}
```