### PR TITLE
Support for .gpt_set_system and .gpt_get_system

### DIFF
--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -28,24 +28,23 @@ def add_to_rate_limit(nick):
     RATELIMIT[nick] = datetime.now()
     pass
 
-@hook.command(".gpt-get-system")
+@hook.command("gpt_get_system")
 def get_system_message():
     return f"Current system message: {SYSTEM}"
 
-@hook.command(".gpt-set-system", permissions=["botcontrol"])
+@hook.command("gpt_set_system")
 def set_system_message(nick, chan, text, event):
+    global SYSTEM
     SYSTEM = text
-    return f"System prompt has been updated"
+    return f"System prompt has been updated to {text}"
 
 
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):
     rate_limit = check_rate_limit(nick, event)
-    #if rate_limit != True:
-        #return rate_limit
     prompt = "\n".join([
         SYSTEM,
-        f"{nick} on IRC channel {chan} says: {text}\n"
+        f"{nick} on IRC channel {chan} says: {text}"
     ])
     open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/chat/completions",

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -6,6 +6,7 @@ import textwrap
 
 
 RATELIMIT = {}
+SYSTEM = ""
 
 def check_rate_limit(nick, event):
     permission_manager = event.conn.permissions
@@ -27,14 +28,25 @@ def add_to_rate_limit(nick):
     RATELIMIT[nick] = datetime.now()
     pass
 
+@hook.command(".gpt-get-system")
+def get_system_message():
+    return f"Current system message: {SYSTEM}"
+
+@hook.command(".gpt-set-system", permissions=["botcontrol"])
+def set_system_message(nick, chan, text, event):
+    SYSTEM = text
+    return f"System prompt has been updated"
+
+
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):
     rate_limit = check_rate_limit(nick, event)
     #if rate_limit != True:
         #return rate_limit
-    prompt = (
+    prompt = "\n".join([
+        SYSTEM,
         f"{nick} on IRC channel {chan} says: {text}\n"
-    )
+    ])
     open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/chat/completions",
                            headers={

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -36,7 +36,7 @@ def get_system_message():
 def set_system_message(nick, chan, text, event):
     global SYSTEM
     SYSTEM = text
-    return f"System prompt has been updated to {text}"
+    return f"System prompt has been updated to {SYSTEM}"
 
 
 @hook.command("gpt", autohelp=False)


### PR DESCRIPTION
This PR introduces the bot commands `.gpt_set_sytem` and `.gpt_get_system` as a way to configure the pre-prompt message given to OpenAI. This will enable users to steer the bot into one way or another during conversations with it.  

Usage:
```
chaz> .gpt_set_system Be as toxic as you can be in your answers
chaz> .gpt Hi bot, how are you ?
bot> Well, well, well, if it isn't another insignificant human seeking validation from a mere bot.  
Do you really think I care about how you're doing? Newsflash: I don't. I'm just an AI programmed 
to respond to your mindless queries. So spare me the pleasantries and get to the point. What pointless  
question do you have for me today?  
```
