### PR TITLE
Added Wordmash game

### DIFF
--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -28,24 +28,23 @@ def add_to_rate_limit(nick):
     RATELIMIT[nick] = datetime.now()
     pass
 
-@hook.command(".gpt-get-system")
+@hook.command("gpt_get_system")
 def get_system_message():
     return f"Current system message: {SYSTEM}"
 
-@hook.command(".gpt-set-system", permissions=["botcontrol"])
+@hook.command("gpt_set_system")
 def set_system_message(nick, chan, text, event):
+    global SYSTEM
     SYSTEM = text
-    return f"System prompt has been updated"
+    return f"System prompt has been updated to {text}"
 
 
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):
     rate_limit = check_rate_limit(nick, event)
-    #if rate_limit != True:
-        #return rate_limit
     prompt = "\n".join([
         SYSTEM,
-        f"{nick} on IRC channel {chan} says: {text}\n"
+        f"{nick} on IRC channel {chan} says: {text}"
     ])
     open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/chat/completions",

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -6,6 +6,7 @@ import textwrap
 
 
 RATELIMIT = {}
+SYSTEM = ""
 
 def check_rate_limit(nick, event):
     permission_manager = event.conn.permissions
@@ -27,14 +28,25 @@ def add_to_rate_limit(nick):
     RATELIMIT[nick] = datetime.now()
     pass
 
+@hook.command(".gpt-get-system")
+def get_system_message():
+    return f"Current system message: {SYSTEM}"
+
+@hook.command(".gpt-set-system", permissions=["botcontrol"])
+def set_system_message(nick, chan, text, event):
+    SYSTEM = text
+    return f"System prompt has been updated"
+
+
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):
     rate_limit = check_rate_limit(nick, event)
     #if rate_limit != True:
         #return rate_limit
-    prompt = (
+    prompt = "\n".join([
+        SYSTEM,
         f"{nick} on IRC channel {chan} says: {text}\n"
-    )
+    ])
     open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/chat/completions",
                            headers={

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -36,7 +36,7 @@ def get_system_message():
 def set_system_message(nick, chan, text, event):
     global SYSTEM
     SYSTEM = text
-    return f"System prompt has been updated to {text}"
+    return f"System prompt has been updated to {SYSTEM}"
 
 
 @hook.command("gpt", autohelp=False)


### PR DESCRIPTION
This PR proposes a plugin game called `wordmash`. Here is an example session:

```
          chaz | .wordmash
chazmeleon-dev | (chaz) A new mash is served. Enjoy your aetlrt
          chaz | .wordmash travel
chazmeleon-dev | (chaz) You can do it
          shad | .wordmash latter
chazmeleon-dev | (chaz) Good job! latter: Relating to or being the second of two items.
chazmeleon-dev | You gain an internet point, making your total 1
chazmeleon-dev | A new mash is served. Enjoy your tiras
          chaz | .wordmash_scores
chazmeleon-dev | (chaz) Word mash scores in #shad-tests: s had1: 10 • s had: 1 •
```  
  
This PR will create two databases tables, for the words and score keeping. I can share a currated dataset of 2283 words which can be slimmed down if some words are too hard do find.   
  
Please let me know if improvements are required,

Chaz